### PR TITLE
Add naive option to DateTimeField

### DIFF
--- a/cushion/field.py
+++ b/cushion/field.py
@@ -180,12 +180,21 @@ class DateTimeField(Field):
             return dt
         if isinstance(dt, basestring):
             try:
-                return iso8601.parse_date(dt)
+                if not self._naive:
+                    return iso8601.parse_date(dt)
+                else:
+                    # If dt is without a time zone then this will return a naive dt
+                    # else it will handle it like the above
+                    return iso8601.parse_date(dt, default_timezone=None)
             except iso8601.ParseError:
                 raise ValueError('invalid date format')
         raise ValueError('date must be iso8601 or datetime object')
 
     def __init__(self, **kw):
+        self._naive = False
+        if 'naive' in kw:
+            self._naive = kw['naive']
+            del kw['naive']
         super(DateTimeField, self).__init__(loader=self._load_date, **kw)
 
     def to_d(self, instance):

--- a/cushion/field.py
+++ b/cushion/field.py
@@ -2,6 +2,7 @@
 from base64 import b64decode, b64encode
 
 from datetime import datetime
+from json import loads
 import iso8601
 
 
@@ -199,7 +200,7 @@ class DateTimeField(Field):
 
     def to_d(self, instance):
         val = self._get_value(instance)
-        return val.utcnow().isoformat() if val else ''
+        return val.isoformat() if val else ''
 
 
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -29,6 +29,8 @@ class Something(Model):
     b = BooleanField()
     pic = ByteField()
 
+class ModelWithNaiveDateTime(Model):
+    d = DateTimeField(default=datetime.utcnow(), naive=True)
 
 class Outter(Model):
     some = RefField(Something)
@@ -82,6 +84,14 @@ class TestField(unittest.TestCase):
         s = Something().save()
         assert s.d < datetime.utcnow(), "date bogus"
 
+    def test_datetime_field_is_naive(self):
+        s = ModelWithNaiveDateTime().save()
+        self.assertTrue(s.d.tzinfo == None)
+
+    def test_datetime_field_is_not_naive(self):
+        s = Something().save()
+        self.assertFalse(s.d.tzinfo != None)
+
     def test_listfield(self):
         s = Something()
         s.ll.append('feh')
@@ -97,5 +107,3 @@ class TestField(unittest.TestCase):
         assert len(s.dd)==1, "bogus len"
         s0 = Something.load(s.id)
         assert s.dd['feh'] == s0.dd['feh']
-
-


### PR DESCRIPTION
Added the ability to set a DateTimeField to work with Naive times. This allows you to do comparisons on other naive datetimes. I also fixed a bug where to_d would return utcnow and set this value in the database instead of the datetime.

e.g.
expire = DateTimeField(naive=True) #"expires": "2015-03-11T22:01:16.561412"