### PR TITLE
Expose id setter

### DIFF
--- a/cushion/model.py
+++ b/cushion/model.py
@@ -45,6 +45,10 @@ class Model(object):
     def id(self):
         return self.__id
 
+    @id.setter
+    def id(self, value):
+        self.__id = value
+
     @property
     def type(self):
         return self.__class__.__name__.lower()


### PR DESCRIPTION
I exposed the id setter on the model objects. I'm not quite sure how iOS handles setting id's but this was an easy way to set a custom id on a document.


user = User(id="u:"+gen_salt(40))
user.save()