### PR TITLE
saving raw values upon assignment for later access

### DIFF
--- a/cushion/model.py
+++ b/cushion/model.py
@@ -4,7 +4,6 @@ from .persist import Persist
 from .view import View
 
 
-
 class DocTypeMismatch(Exception):
     """ Raised when document tries to instantiate from other doc type """
 
@@ -33,7 +32,6 @@ class NewModelClass(type):
             cls._update_fields()
 
 
-
 class Model(object):
 
     __metaclass__ = NewModelClass
@@ -57,6 +55,7 @@ class Model(object):
         super(Model, self).__init__()
         self.__class__._update_fields()
         self._data = {}
+        self._raw_data = {}
         if 'type' in kw:
             # cleanup 'type' inbound
             if kw['type'] != self.type: raise DocTypeMismatch()
@@ -66,10 +65,14 @@ class Model(object):
             self.__id = kw['_id']
             del kw['_id']
         for k,v in kw.iteritems():
+            self._raw_data[k] = v
             setattr(self, k, v)
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.id == other.id
+
+    def rawval(self, k):
+        return self._raw_data.get(k)
 
     @classmethod
     def _update_fields(cls):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -10,7 +10,7 @@ from ..cushion.field import (
     DateTimeField, ListField, DictField, ByteField
     )
 
-from ..cushion.persist import set_connection 
+from ..cushion.persist import set_connection
 from ..cushion.persist.mem import MemConnection
 
 
@@ -29,8 +29,10 @@ class Something(Model):
     b = BooleanField()
     pic = ByteField()
 
+
 class ModelWithNaiveDateTime(Model):
     d = DateTimeField(default=datetime.utcnow(), naive=True)
+
 
 class Outter(Model):
     some = RefField(Something)
@@ -79,6 +81,8 @@ class TestField(unittest.TestCase):
         assert o.some.txt == 'good times'
         o2 = Outter.load(o.id)
         assert o2.some.txt == 'good times'
+        print o._raw_data
+        assert o2.rawval('some') == s.id
 
     def test_datetime_field(self):
         s = Something().save()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,8 +1,8 @@
 import unittest
 
 from ..cushion.model import Model, DocTypeMismatch, DocTypeNotFound
-from ..cushion.field import Field
-from ..cushion.persist import set_connection 
+from ..cushion.field import Field, TextField
+from ..cushion.persist import set_connection
 from ..cushion.persist.mem import MemConnection
 
 
@@ -22,6 +22,7 @@ class FakeModel(Model):
 
     twentythree = Field(default=23)
     somestr = Field()
+    txt = TextField()
 
 
 class TestModel(unittest.TestCase):
@@ -48,4 +49,11 @@ class TestModel(unittest.TestCase):
         e3 = FakeModel().save()
         assert e1 == e2, "not equal"
         assert not e1 == e3, "equal but shouldn't be"
+
+    def test_raw(self):
+        f = FakeModel(txt=55).save()
+        self.assertEqual( 55, f.rawval('txt') )
+        self.assertEqual( '55', f.txt )
+
+
 


### PR DESCRIPTION
Right now, it's nigh impossible to retrieve the actual data assigned to a model field.  This adds a simple method of  `rawval(key)` to the `Model` class.

This is an initial move towards loading fields upon access and not at initialization which will be a performance enhancement for objects like RefField that may not be needed at all on object load.